### PR TITLE
Optional confirmations, transcript sending, and a default topic.

### DIFF
--- a/src/commands/close.js
+++ b/src/commands/close.js
@@ -82,46 +82,115 @@ module.exports = {
 		let pre = fs.existsSync(paths.text) || fs.existsSync(paths.log)
 			? `You will be able to view an archived version later with \`${config.prefix}transcript ${ticket.id}\``
 			: '';
-
-		let confirm = await message.channel.send(
-			new MessageEmbed()
-				.setColor(config.colour)
-				.setAuthor(message.author.username, message.author.displayAvatarURL())
-				.setTitle('❔ Are you sure?')
-				.setDescription(`${pre}\n**React with ✅ to confirm.**`)
-				.setFooter(guild.name + ' | Expires in 15 seconds', guild.iconURL())
-		);
-
-		await confirm.react('✅');
-
-		const collector = confirm.createReactionCollector(
-			(r, u) => r.emoji.name === '✅' && u.id === message.author.id, {
-				time: 15000
-			});
-
-		collector.on('collect', async () => {
-			let users = [];
-			if (channel.id !== message.channel.id) {
-				channel.send(
-					new MessageEmbed()
-						.setColor(config.colour)
-						.setAuthor(message.author.username, message.author.displayAvatarURL())
-						.setTitle('**Ticket closed**')
-						.setDescription(`Ticket closed by ${message.author}`)
-						.setFooter(guild.name, guild.iconURL())
-				);
-			}
-
-			confirm.reactions.removeAll();
-			confirm.edit(
+		if (config.commands.close.confirmation) {
+			let confirm = await message.channel.send(
 				new MessageEmbed()
 					.setColor(config.colour)
 					.setAuthor(message.author.username, message.author.displayAvatarURL())
-					.setTitle(`✅ **Ticket ${ticket.id} closed**`)
-					.setDescription('The channel will be automatically deleted in a few seconds, once the contents have been archived.')
-					.setFooter(guild.name, guild.iconURL())
+					.setTitle('❔ Are you sure?')
+					.setDescription(`${pre}\n**React with ✅ to confirm.**`)
+					.setFooter(guild.name + ' | Expires in 15 seconds', guild.iconURL())
 			);
 
+			await confirm.react('✅');
+
+			const collector = confirm.createReactionCollector(
+				(r, u) => r.emoji.name === '✅' && u.id === message.author.id, {
+				time: 15000
+			});
+
+			collector.on('collect', async () => {
+				let users = [];
+				if (channel.id !== message.channel.id) {
+					channel.send(
+						new MessageEmbed()
+							.setColor(config.colour)
+							.setAuthor(message.author.username, message.author.displayAvatarURL())
+							.setTitle('**Ticket closed**')
+							.setDescription(`Ticket closed by ${message.author}`)
+							.setFooter(guild.name, guild.iconURL())
+					);
+				}
+
+				confirm.reactions.removeAll();
+				confirm.edit(
+					new MessageEmbed()
+						.setColor(config.colour)
+						.setAuthor(message.author.username, message.author.displayAvatarURL())
+						.setTitle(`✅ **Ticket ${ticket.id} closed**`)
+						.setDescription('The channel will be automatically deleted in a few seconds, once the contents have been archived.')
+						.setFooter(guild.name, guild.iconURL())
+				);
+				success = true;
+				closeTicket();
+				if (config.commands.close.send_transcripts) {
+					sendTranscript();
+				}
+			});
+
+
+			collector.on('end', () => {
+				if (!success) {
+					confirm.reactions.removeAll();
+					confirm.edit(
+						new MessageEmbed()
+							.setColor(config.err_colour)
+							.setAuthor(message.author.username, message.author.displayAvatarURL())
+							.setTitle('❌ **Expired**')
+							.setDescription('You took too long to react; confirmation failed.')
+							.setFooter(guild.name, guild.iconURL()));
+
+					message.delete({
+						timeout: 10000
+					})
+						.then(() => confirm.delete());
+				}
+			});
+		} else {
+			success = true;
+			closeTicket();
+		}
+
+		async function closeTicket() {
+			// update database
+			ticket.update({
+				open: false
+			}, {
+				where: {
+					channel: channel.id
+				}
+			});
+
+			// delete messages and channel
+			setTimeout(() => {
+				channel.delete();
+				if (channel.id !== message.channel.id)
+					message.delete()
+						.then(() => confirm.delete());
+			}, 5000);
+
+			log.info(`${message.author.tag} closed a ticket (#ticket-${ticket.id})`);
+
+			if (config.logs.discord.enabled) {
+				let embed = new MessageEmbed()
+					.setColor(config.colour)
+					.setAuthor(message.author.username, message.author.displayAvatarURL())
+					.setTitle(`Ticket ${ticket.id} closed`)
+					.addField('Creator', `<@${ticket.creator}>`, true)
+					.addField('Closed by', message.author, true)
+					.setFooter(guild.name, guild.iconURL())
+					.setTimestamp();
+
+				if (users.length > 1)
+					embed.addField('Members', users.map(u => `<@${u}>`).join('\n'));
+
+				client.channels.cache.get(config.logs.discord.channel).send(embed);
+			}
+		}
+		if (config.commands.close.send_transcripts) {
+			sendTranscript();
+		}
+		async function sendTranscript() {
 			if (config.transcripts.text.enabled || config.transcripts.web.enabled) {
 				let u = await client.users.fetch(ticket.creator);
 
@@ -160,71 +229,17 @@ module.exports = {
 					}
 
 					res.embed = embed;
-					
 					try {
-						dm.send(res);
-						if (config.transcripts.channel.length > 1) client.channels.cache.get(config.transcripts.channel).send(res);
+						if (success) {
+							dm.send(res);
+							if (config.transcripts.channel.length > 1) client.channels.cache.get(config.transcripts.channel).send(res);
+						}
 					} catch (e) {
 						message.channel.send('❌ Couldn\'t send DM or transcript log message');
 					}
 				}
 			}
-
-			// update database
-			success = true;
-			ticket.update({
-				open: false
-			}, {
-				where: {
-					channel: channel.id
-				}
-			});
-
-			// delete messages and channel
-			setTimeout(() => {
-				channel.delete();
-				if (channel.id !== message.channel.id)
-					message.delete()
-						.then(() => confirm.delete());
-			}, 5000);
-
-			log.info(`${message.author.tag} closed a ticket (#ticket-${ticket.id})`);
-
-			if (config.logs.discord.enabled) {
-				let embed = new MessageEmbed()
-					.setColor(config.colour)
-					.setAuthor(message.author.username, message.author.displayAvatarURL())
-					.setTitle(`Ticket ${ticket.id} closed`)
-					.addField('Creator', `<@${ticket.creator}>`, true)
-					.addField('Closed by', message.author, true)
-					.setFooter(guild.name, guild.iconURL())
-					.setTimestamp();
-				
-				if (users.length > 1)
-					embed.addField('Members', users.map(u => `<@${u}>`).join('\n'));
-				
-				client.channels.cache.get(config.logs.discord.channel).send(embed);
-			}
-		});
-
-
-		collector.on('end', () => {
-			if (!success) {
-				confirm.reactions.removeAll();
-				confirm.edit(
-					new MessageEmbed()
-						.setColor(config.err_colour)
-						.setAuthor(message.author.username, message.author.displayAvatarURL())
-						.setTitle('❌ **Expired**')
-						.setDescription('You took too long to react; confirmation failed.')
-						.setFooter(guild.name, guild.iconURL()));
-
-				message.delete({
-					timeout: 10000
-				})
-					.then(() => confirm.delete());
-			}
-		});
+		}
 
 	}
 };

--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -64,7 +64,7 @@ module.exports = {
 			}
 
 		}
-		if (message.author.id !== ticket.creator && !message.member.roles.cache.has(config.staff_role)) 
+		if (message.author.id !== ticket.creator && !message.member.roles.cache.has(config.staff_role))
 			return channel.send(
 				new MessageEmbed()
 					.setColor(config.err_colour)
@@ -75,103 +75,100 @@ module.exports = {
 					.addField('Help', `Type \`${config.prefix}help ${this.name}\` for more information`)
 					.setFooter(guild.name, guild.iconURL())
 			);
-		
+
 		let success;
-
-		let confirm = await message.channel.send(
-			new MessageEmbed()
-				.setColor(config.colour)
-				.setAuthor(message.author.username, message.author.displayAvatarURL())
-				.setTitle('❔ Are you sure?')
-				.setDescription(
-					`:warning: This action is **irreversible**, the ticket will be completely removed from the database.
-					You will **not** be able to view a transcript/archive of the channel later.
-					Use the \`close\` command instead if you don't want this behaviour.\n**React with ✅ to confirm.**`)
-				.setFooter(guild.name + ' | Expires in 15 seconds', guild.iconURL())
-		);
-
-		await confirm.react('✅');
-
-		const collector = confirm.createReactionCollector(
-			(r, u) => r.emoji.name === '✅' && u.id === message.author.id, {
-				time: 15000
-			});
-
-		collector.on('collect', async () => {
-			if (channel.id !== message.channel.id)
-				channel.send(
-					new MessageEmbed()
-						.setColor(config.colour)
-						.setAuthor(message.author.username, message.author.displayAvatarURL())
-						.setTitle('**Ticket deleted**')
-						.setDescription(`Ticket deleted by ${message.author}`)
-						.setFooter(guild.name, guild.iconURL())
-				);
-
-			confirm.reactions.removeAll();
-			confirm.edit(
+		if (config.commands.delete.confirmation) {
+			let confirm = await message.channel.send(
 				new MessageEmbed()
 					.setColor(config.colour)
 					.setAuthor(message.author.username, message.author.displayAvatarURL())
-					.setTitle(`✅ **Ticket ${ticket.id} deleted**`)
-					.setDescription('The channel will be automatically deleted in a few seconds.')
-					.setFooter(guild.name, guild.iconURL())
+					.setTitle('❔ Are you sure?')
+					.setDescription(
+						`:warning: This action is **irreversible**, the ticket will be completely removed from the database.
+						You will **not** be able to view a transcript/archive of the channel later.
+						Use the \`close\` command instead if you don't want this behaviour.\n**React with ✅ to confirm.**`)
+					.setFooter(guild.name + ' | Expires in 15 seconds', guild.iconURL())
 			);
 
-			let txt = join(__dirname, `../../user/transcripts/text/${ticket.get('channel')}.txt`),
-				raw = join(__dirname, `../../user/transcripts/raw/${ticket.get('channel')}.log`),
-				json = join(__dirname, `../../user/transcripts/raw/entities/${ticket.get('channel')}.json`);
+			await confirm.react('✅');
 
-			if (fs.existsSync(txt)) fs.unlinkSync(txt);
-			if (fs.existsSync(raw)) fs.unlinkSync(raw);
-			if (fs.existsSync(json)) fs.unlinkSync(json);
+			const collector = confirm.createReactionCollector(
+				(r, u) => r.emoji.name === '✅' && u.id === message.author.id, {
+				time: 15000
+			});
 
-			// update database
-			success = true;
-			ticket.destroy(); // remove ticket from database
-
-			// delete messages and channel
-			setTimeout(() => {
-				channel.delete();
+			collector.on('collect', async () => {
 				if (channel.id !== message.channel.id)
-					message.delete()
-						.then(() => confirm.delete());
-			}, 5000);
+					channel.send(
+						new MessageEmbed()
+							.setColor(config.colour)
+							.setAuthor(message.author.username, message.author.displayAvatarURL())
+							.setTitle('**Ticket deleted**')
+							.setDescription(`Ticket deleted by ${message.author}`)
+							.setFooter(guild.name, guild.iconURL())
+					);
 
-			log.info(`${message.author.tag} deleted a ticket (#ticket-${ticket.id})`);
-
-			if (config.logs.discord.enabled) {
-				client.channels.cache.get(config.logs.discord.channel).send(
-					new MessageEmbed()
-						.setColor(config.colour)
-						.setAuthor(message.author.username, message.author.displayAvatarURL())
-						.setTitle('Ticket deleted')
-						.addField('Creator', `<@${ticket.creator}>`, true)
-						.addField('Deleted by', message.author, true)
-						.setFooter(guild.name, guild.iconURL())
-						.setTimestamp()
-				);
-			}
-		});
-
-
-		collector.on('end', () => {
-			if (!success) {
 				confirm.reactions.removeAll();
 				confirm.edit(
 					new MessageEmbed()
-						.setColor(config.err_colour)
+						.setColor(config.colour)
 						.setAuthor(message.author.username, message.author.displayAvatarURL())
-						.setTitle('❌ **Expired**')
-						.setDescription('You took too long to react; confirmation failed.')
-						.setFooter(guild.name, guild.iconURL()));
+						.setTitle(`✅ **Ticket ${ticket.id} deleted**`)
+						.setDescription('The channel will be automatically deleted in a few seconds.')
+						.setFooter(guild.name, guild.iconURL())
+				);
+			});
+			collector.on('end', () => {
+				if (!success) {
+					confirm.reactions.removeAll();
+					confirm.edit(
+						new MessageEmbed()
+							.setColor(config.err_colour)
+							.setAuthor(message.author.username, message.author.displayAvatarURL())
+							.setTitle('❌ **Expired**')
+							.setDescription('You took too long to react; confirmation failed.')
+							.setFooter(guild.name, guild.iconURL()));
 
-				message.delete({
-					timeout: 10000
-				})
+					message.delete({
+						timeout: 10000
+					})
+						.then(() => confirm.delete());
+				}
+			});
+		}
+		let txt = join(__dirname, `../../user/transcripts/text/${ticket.get('channel')}.txt`),
+			raw = join(__dirname, `../../user/transcripts/raw/${ticket.get('channel')}.log`),
+			json = join(__dirname, `../../user/transcripts/raw/entities/${ticket.get('channel')}.json`);
+
+		if (fs.existsSync(txt)) fs.unlinkSync(txt);
+		if (fs.existsSync(raw)) fs.unlinkSync(raw);
+		if (fs.existsSync(json)) fs.unlinkSync(json);
+
+		// update database
+		success = true;
+		ticket.destroy(); // remove ticket from database
+
+		// delete messages and channel
+		setTimeout(() => {
+			channel.delete();
+			if (channel.id !== message.channel.id)
+				message.delete()
 					.then(() => confirm.delete());
-			}
-		});
+		}, 5000);
 
+		log.info(`${message.author.tag} deleted a ticket (#ticket-${ticket.id})`);
+
+		if (config.logs.discord.enabled) {
+			client.channels.cache.get(config.logs.discord.channel).send(
+				new MessageEmbed()
+					.setColor(config.colour)
+					.setAuthor(message.author.username, message.author.displayAvatarURL())
+					.setTitle('Ticket deleted')
+					.addField('Creator', `<@${ticket.creator}>`, true)
+					.addField('Deleted by', message.author, true)
+					.setFooter(guild.name, guild.iconURL())
+					.setTimestamp()
+			);
+		}
 	}
 };

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -26,7 +26,7 @@ module.exports = {
 			let cmds = [];
 
 			for (let command of commands) {
-				if (command.hide) continue;
+				if (command.hide || command.disabled) continue;
 				if (command.permission && !message.member.hasPermission(command.permission)) continue;
 
 				let desc = command.description;

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -76,11 +76,9 @@ module.exports = {
 					.setDescription('Please limit your ticket topic to less than 256 characters. A short sentence will do.')
 					.setFooter(guild.name, guild.iconURL())
 			);
-		} else if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
-			topic = config.default_topic;
 		}
 		else if (topic.length < 1) {
-			topic = 'No topic given';
+			topic = config.tickets.default_topic.command;
 		}
 
 		let ticket = await Ticket.create({

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -11,6 +11,7 @@ const log = new Logger();
 const { MessageEmbed } = require('discord.js');
 const fs = require('fs');
 const { join } = require('path');
+const config = require(join(__dirname, '../../user/', require('../').config));
 
 module.exports = {
 	name: 'new',
@@ -19,12 +20,17 @@ module.exports = {
 	aliases: ['ticket', 'open'],
 	example: 'new my server won\'t start',
 	args: false,
+	disabled: !config.commands.new.enabled,
 	async execute(client, message, args, {config, Ticket}) {
+
+		if (!config.commands.new.enabled) return; // stop if the command is disabled
+
+
 		const guild = client.guilds.cache.get(config.guild);
 
 		const supportRole = guild.roles.cache.get(config.staff_role);
-		if (config.commands.new.enabled) {
-			if (!supportRole)
+		
+		if (!supportRole)
 			return message.channel.send(
 				new MessageEmbed()
 					.setColor(config.err_colour)
@@ -196,6 +202,6 @@ module.exports = {
 
 
 		}).catch(log.error);
-		}
+
 	},
 };

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -23,7 +23,8 @@ module.exports = {
 		const guild = client.guilds.cache.get(config.guild);
 
 		const supportRole = guild.roles.cache.get(config.staff_role);
-		if (!supportRole)
+		if (config.commands.new.enabled) {
+			if (!supportRole)
 			return message.channel.send(
 				new MessageEmbed()
 					.setColor(config.err_colour)
@@ -75,7 +76,7 @@ module.exports = {
 					.setDescription('Please limit your ticket topic to less than 256 characters. A short sentence will do.')
 					.setFooter(guild.name, guild.iconURL())
 			);
-		else if (topic.length < 1) topic = 'No topic given';
+		else if (topic.length < 1) topic = config.default_topic;
 
 		let ticket = await Ticket.create({
 			channel: '',
@@ -192,5 +193,6 @@ module.exports = {
 
 
 		}).catch(log.error);
+		}
 	},
 };

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -76,7 +76,7 @@ module.exports = {
 					.setDescription('Please limit your ticket topic to less than 256 characters. A short sentence will do.')
 					.setFooter(guild.name, guild.iconURL())
 			);
-		} if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
+		} else if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
 			topic = config.default_topic;
 		}
 		else if (topic.length < 1) {

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -67,7 +67,7 @@ module.exports = {
 
 
 		let topic = args.join(' ');
-		if (topic.length > 256)
+		if (topic.length > 256) {
 			return message.channel.send(
 				new MessageEmbed()
 					.setColor(config.err_colour)
@@ -76,7 +76,12 @@ module.exports = {
 					.setDescription('Please limit your ticket topic to less than 256 characters. A short sentence will do.')
 					.setFooter(guild.name, guild.iconURL())
 			);
-		else if (topic.length < 1) topic = config.default_topic;
+		} else if (/^[a-zA-Z0-9]+$/.test(config.default_topic)) {
+			topic = config.default_topic;
+		}
+		else if (topic.length < 1) {
+			topic = 'No topic given';
+		}
 
 		let ticket = await Ticket.create({
 			channel: '',

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -76,7 +76,7 @@ module.exports = {
 					.setDescription('Please limit your ticket topic to less than 256 characters. A short sentence will do.')
 					.setFooter(guild.name, guild.iconURL())
 			);
-		} else if (/^[a-zA-Z0-9]+$/.test(config.default_topic)) {
+		} if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
 			topic = config.default_topic;
 		}
 		else if (topic.length < 1) {

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -89,7 +89,13 @@ module.exports = {
 			}
 		}
 
-		let topic = config.default_topic;
+
+		if (/^[a-zA-Z0-9]+$/.test(config.default_topic)) {
+			topic = config.default_topic;
+		} else {
+			topic = 'No topic given (created via panel)';
+		}
+		
 
 		let ticket = await Ticket.create({
 			channel: '',

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -90,7 +90,7 @@ module.exports = {
 		}
 
 
-		if (/^[a-zA-Z0-9]+$/.test(config.default_topic)) {
+		if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
 			topic = config.default_topic;
 		} else {
 			topic = 'No topic given (created via panel)';

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -89,7 +89,7 @@ module.exports = {
 			}
 		}
 
-		let topic = 'No topic given (created via panel)';
+		let topic = config.default_topic;
 
 		let ticket = await Ticket.create({
 			channel: '',

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -89,14 +89,12 @@ module.exports = {
 			}
 		}
 
-
 		if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
-			topic = config.default_topic;
+			topic = config.tickets.default_topic.panel;
 		} else {
 			topic = 'No topic given (created via panel)';
 		}
 		
-
 		let ticket = await Ticket.create({
 			channel: '',
 			creator: u.id,

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -89,11 +89,7 @@ module.exports = {
 			}
 		}
 
-		if (!/("|'|`)("|'|`)/.test(config.default_topic)) {
-			topic = config.tickets.default_topic.panel;
-		} else {
-			topic = 'No topic given (created via panel)';
-		}
+		let topic = config.tickets.default_topic.command;
 		
 		let ticket = await Ticket.create({
 			channel: '',

--- a/user/config.js
+++ b/user/config.js
@@ -47,7 +47,6 @@ module.exports = {
 	colour: '#009999',
 	err_colour: 'RED',
 	cooldown: 3,
-	default_topic: '',
 	guild: '', // ID of your guild (REQUIRED)
 	staff_role: '', // ID of your Support Team role (REQUIRED)
 
@@ -65,6 +64,10 @@ module.exports = {
 	},
 
 	tickets: {
+		default_topic: {
+			command: 'No topic given',
+			panel: 'Created via panel'
+		},
 		category: '', // ID of your tickets category (REQUIRED)
 		send_img: true,
 		ping: 'here',

--- a/user/config.js
+++ b/user/config.js
@@ -47,9 +47,22 @@ module.exports = {
 	colour: '#009999',
 	err_colour: 'RED',
 	cooldown: 3,
-
+	default_topic: 'Support Needed',
 	guild: '', // ID of your guild (REQUIRED)
 	staff_role: '', // ID of your Support Team role (REQUIRED)
+
+	commands: {
+		close: {
+			confirmation: true,
+			send_transcripts: true
+		},
+		delete: {
+			confirmation: true
+		},
+		new: {
+			enabled: true
+		},
+	},
 
 	tickets: {
 		category: '', // ID of your tickets category (REQUIRED)

--- a/user/config.js
+++ b/user/config.js
@@ -50,6 +50,21 @@ module.exports = {
 	guild: '', // ID of your guild (REQUIRED)
 	staff_role: '', // ID of your Support Team role (REQUIRED)
 
+	tickets: {
+		category: '', // ID of your tickets category (REQUIRED)
+		send_img: true,
+		ping: 'here',
+		text: `Hello there, {{ tag }}!
+		A member of staff will assist you shortly.
+		In the mean time, please describe your issue in as much detail as possible! :)`,
+		pin: false,
+		max: 3,
+		default_topic: {
+			command: 'No topic given',
+			panel: 'Created via panel'
+		}
+	},
+
 	commands: {
 		close: {
 			confirmation: true,
@@ -61,21 +76,6 @@ module.exports = {
 		new: {
 			enabled: true
 		},
-	},
-
-	tickets: {
-		default_topic: {
-			command: 'No topic given',
-			panel: 'Created via panel'
-		},
-		category: '', // ID of your tickets category (REQUIRED)
-		send_img: true,
-		ping: 'here',
-		text: `Hello there, {{ tag }}!
-		A member of staff will assist you shortly.
-		In the mean time, please describe your issue in as much detail as possible! :)`,
-		pin: false,
-		max: 3
 	},
 
 	transcripts: {

--- a/user/config.js
+++ b/user/config.js
@@ -47,7 +47,7 @@ module.exports = {
 	colour: '#009999',
 	err_colour: 'RED',
 	cooldown: 3,
-	default_topic: 'Support Needed',
+	default_topic: '',
 	guild: '', // ID of your guild (REQUIRED)
 	staff_role: '', // ID of your Support Team role (REQUIRED)
 


### PR DESCRIPTION
#### Information

- [ ] This includes major changes (breaking changes)
- [x] This includes minor changes (minimal usage changes, minor new features)
- [ ] This includes patches (bug fixes, documentation changes etc)

#### Is this related to an issue?
No.
#### Changes made

I added a few options for the user to make their DiscordTickets bot more streamline and more configurable. In my use case, these changes will be extremely useful to prevent users from committing actions I'd ask them not to do.

These options include: 

- Return confirmation on close command.
- Disable/Enable transcript sending to the ticket creator.
- Return confirmation on delete command.
- Disable/Enable the new command. 

The `-close` and `-delete` commands now have the option to return a confirmation. 
The user can decide if they would like to send transcripts to ticket creators.

Also included:
- Default topic when none is provided.

When the `-new` command isn't provided a second argument, the `default_topic` config item will be filled into the topic. This also works with panels, so panels can be provided a default topic.

#### Confirmations

- [ ] I have updated any necessary documentation
- [x] This uses consistent code style
- [x] This is tested and works

Documentation that hasn't been updated, and cannot be updated by me, is on the wiki. 
